### PR TITLE
Fix for build on Linux 5.19.0, g++ 12.2

### DIFF
--- a/src/qt/paymentserver.cpp
+++ b/src/qt/paymentserver.cpp
@@ -147,7 +147,8 @@ void PaymentServer::LoadRootCAs(X509_STORE* _store)
     int nRootCerts = 0;
     const QDateTime currentTime = QDateTime::currentDateTime();
 
-    Q_FOREACH (const QSslCertificate& cert, certList) {
+    //Q_FOREACH (const QSslCertificate& cert, certList) {
+    for (const QSslCertificate& cert : certList) {
         // Don't log NULL certificates
         if (cert.isNull())
             continue;
@@ -318,7 +319,8 @@ void PaymentServer::ipcParseCommandLine(int argc, char* argv[])
 bool PaymentServer::ipcSendCommandLine()
 {
     bool fResult = false;
-    Q_FOREACH (const QString& r, savedPaymentRequests)
+    //Q_FOREACH (const QString& r, savedPaymentRequests)
+    for (const QString& r : savedPaymentRequests)
     {
         QLocalSocket* socket = new QLocalSocket();
         socket->connectToServer(ipcServerName(), QIODevice::WriteOnly);
@@ -444,7 +446,8 @@ void PaymentServer::uiReady()
     initNetManager();
 
     saveURIs = false;
-    Q_FOREACH (const QString& s, savedPaymentRequests)
+    //Q_FOREACH (const QString& s, savedPaymentRequests)
+    for (const QString& s : savedPaymentRequests)
     {
         handleURIOrFile(s);
     }
@@ -628,7 +631,8 @@ bool PaymentServer::processPaymentRequest(const PaymentRequestPlus& request, Sen
     QList<std::pair<CScript, CAmount> > sendingTos = request.getPayTo();
     QStringList addresses;
 
-    Q_FOREACH(const PAIRTYPE(CScript, CAmount)& sendingTo, sendingTos) {
+    //Q_FOREACH(const PAIRTYPE(CScript, CAmount)& sendingTo, sendingTos) {
+    for (const PAIRTYPE(CScript, CAmount)& sendingTo : sendingTos) {
         // Extract and check destination addresses
         CTxDestination dest;
         if (ExtractDestination(sendingTo.first, dest)) {
@@ -816,7 +820,8 @@ void PaymentServer::reportSslErrors(QNetworkReply* reply, const QList<QSslError>
     Q_UNUSED(reply);
 
     QString errString;
-    Q_FOREACH (const QSslError& err, errs) {
+    //Q_FOREACH (const QSslError& err, errs) {
+    for (const QSslError& err : errs) {
         qWarning() << "PaymentServer::reportSslErrors: " << err;
         errString += err.errorString() + "\n";
     }

--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -252,7 +252,8 @@ QString TransactionDesc::toHTML(CWallet *wallet, CWalletTx &wtx, TransactionReco
     //
     // PaymentRequest info:
     //
-    Q_FOREACH (const PAIRTYPE(std::string, std::string)& r, wtx.vOrderForm)
+    //Q_FOREACH (const PAIRTYPE(std::string, std::string)& r, wtx.vOrderForm)
+    for (const PAIRTYPE(std::string, std::string)& r : wtx.vOrderForm)
     {
         if (r.first == "PaymentRequest")
         {


### PR DESCRIPTION
Hello! Here it is my build process and errors I got. I edited two files and built successfully, hope you accept pull request.
Here 'v' is 'vim' and 'mk' is like 'date;make;date'
```
##2024-05-13 16:05 install SOSHE SatoshiNetwork
git clone https://github.com/SatosheNetwork/satoshe-core.git
cd satoshe-core/
./autogen.sh
./configure --with-incompatible-bdb
mk
  qt/paymentserver.cpp: In member function ‘bool PaymentServer::handleURI(const QString&, const QString&)’:
  qt/paymentserver.cpp:469:20: warning: ‘QByteArray& QByteArray::append(const QString&)’ is deprecated: Use QString's toUtf8(), toLatin1() or toLocal8Bit() [-Wdeprecated-declarations]
    469 |         temp.append(uri.queryItemValue("r"));
        |         ~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~
  In file included from /usr/include/x86_64-linux-gnu/qt5/QtCore/qhashfunctions.h:44,
                   from /usr/include/x86_64-linux-gnu/qt5/QtCore/qlist.h:47,
                   from /usr/include/x86_64-linux-gnu/qt5/QtCore/QList:1,
                   from qt/paymentrequestplus.h:18:
  /usr/include/x86_64-linux-gnu/qt5/QtCore/qstring.h:1511:20: note: declared here
   1511 | inline QByteArray &QByteArray::append(const QString &s)
        |                    ^~~~~~~~~~
  qt/paymentserver.cpp: In member function ‘bool PaymentServer::processPaymentRequest(const PaymentRequestPlus&, SendCoinsRecipient&)’:
  /usr/include/x86_64-linux-gnu/qt5/QtCore/qglobal.h:1133:5: error: ‘Q_FOREACH_IMPL’ was not declared in this scope
   1133 |     Q_FOREACH_IMPL(variable, Q_FOREACH_JOIN(_container_, __LINE__), container)
        |     ^~~~~~~~~~~~~~
  /usr/include/x86_64-linux-gnu/qt5/QtCore/qglobal.h:1133:5: note: in definition of macro ‘Q_FOREACH’
   1133 |     Q_FOREACH_IMPL(variable, Q_FOREACH_JOIN(_container_, __LINE__), container)
        |     ^~~~~~~~~~~~~~
  make[2]: *** [Makefile:7648: qt/libbitcoinqt_a-paymentserver.o] Error 1
v src/qt/paymentserver.cpp
  152://Q_FOREACH (const QSslCertificate& cert, certList) {
    for (const QSslCertificate& cert : certList) {
  322://Q_FOREACH (const QString& r, savedPaymentRequests)
    for (const QString& r : savedPaymentRequests)
  449://Q_FOREACH (const QString& s, savedPaymentRequests)
    for (const QString& s : savedPaymentRequests)
  634://Q_FOREACH(const PAIRTYPE(CScript, CAmount)& sendingTo, sendingTos) {
    for (const PAIRTYPE(CScript, CAmount)& sendingTo : sendingTos) {
  823://Q_FOREACH (const QSslError& err, errs) {
    for (const QSslError& err : errs) {
mk
  qt/transactiondesc.cpp: In static member function ‘static QString TransactionDesc::toHTML(CWallet*, CWalletTx&, TransactionRecord*, int)’:
  /usr/include/x86_64-linux-gnu/qt5/QtCore/qglobal.h:1133:5: error: ‘Q_FOREACH_IMPL’ was not declared in this scope
   1133 |     Q_FOREACH_IMPL(variable, Q_FOREACH_JOIN(_container_, __LINE__), container)
        |     ^~~~~~~~~~~~~~
  qt/transactiondesc.cpp:255:5: note: in expansion of macro ‘Q_FOREACH’
    255 |     Q_FOREACH (const PAIRTYPE(std::string, std::string)& r, wtx.vOrderForm)
        |     ^~~~~~~~~
v src/qt/transactiondesc.cpp
  256://Q_FOREACH (const PAIRTYPE(std::string, std::string)& r, wtx.vOrderForm)
    for (const PAIRTYPE(std::string, std::string)& r : wtx.vOrderForm)
mk
    CXXLD    libbitcoinconsensus.la
  make[2]: Leaving directory '/mnt/blockchains/crypto/testing/soshe/satoshe-core/src'
  make[1]: Leaving directory '/mnt/blockchains/crypto/testing/soshe/satoshe-core/src'
  Making all in doc/man
  make[1]: Entering directory '/mnt/blockchains/crypto/testing/soshe/satoshe-core/doc/man'
  make[1]: Nothing to be done for 'all'.
  make[1]: Leaving directory '/mnt/blockchains/crypto/testing/soshe/satoshe-core/doc/man'
  make[1]: Entering directory '/mnt/blockchains/crypto/testing/soshe/satoshe-core'
  make[1]: Nothing to be done for 'all-am'.
  make[1]: Leaving directory '/mnt/blockchains/crypto/testing/soshe/satoshe-core'
  Mon May 13 04:23:49 PM MSK 2024
  start date was Mon May 13 04:22:21 PM MSK 2024
ls -l src/qt/satoshe-qt
  -rwxr-xr-x 1 y y 179519552 May 13 16:23 src/qt/satoshe-qt
./src/qt/satoshe-qt
  #works. also there is no limit of using space. 13 weeks of blcokchain life now. no peers
  #to add peers click: Settings -> Options -> Open configuration file, paste there from discord post https://discord.com/channels/1195407195920138351/1209558638268776488/1209563251063660554:
  addnode=82.148.2.179
  addnode=82.97.246.156
  addnode=37.220.83.16
  #save and restart wallet. works!
```